### PR TITLE
Update S3.js

### DIFF
--- a/lib/S3.js
+++ b/lib/S3.js
@@ -30,22 +30,60 @@ var S3StorageProvider = function(options) {
     bucket: this._options.bucket,
     region: this._options.region
   })
+
+  this._queryResult = function(error, res, callback) {
+
+    if (error) {
+      return callback(error)
+    }
+
+    if (res && 'on' in res) {
+      if (res.statusCode >= 200 && res.statusCode <= 209) {
+        return callback(null, res.req.url)
+      }
+
+      var body = ''
+
+      res.on('data', function (chunk) {
+        body += chunk
+      })
+
+      res.on('end', function () {
+        var err = new Error()
+        err.statusCode = res.statusCode
+        err.body = body
+
+        return callback(err)
+      })
+      } else {
+        if (res && 'req' in res){
+          callback(null, res.req.url)
+        } else {
+          callback()
+      }
+    }
+}
 }
 
 S3StorageProvider.prototype.save = function(attachment, callback) {
-  this._client.putFile(attachment.path, this._options.path(attachment), {
-    'x-amz-acl': this._options.acl
-  }, function(error, message) {
-    callback(error, error ? undefined : message.req.url)
+  var self = this
+
+  this._client.putFile(attachment.path, this._options.path(attachment),
+    {'x-amz-acl': this._options.acl }, function(error, res) {
+    self._queryResult(error, res, callback)
   })
 }
 
 S3StorageProvider.prototype.remove = function(attachment, callback) {
+  var self = this
+
   if(!attachment.url) {
     return callback()
   }
 
-  this._client.deleteFile(path.basename(attachment.url), callback)
+  this._client.deleteFile(path.basename(attachment.url), function(error, res) {
+    self._queryResult(error, res, callback)
+  })
 }
 
 module.exports = S3StorageProvider

--- a/test/S3Test.js
+++ b/test/S3Test.js
@@ -282,4 +282,57 @@ describe('S3', function() {
       done()
     })
   })
+
+  it('should check the statusCode of the response', function (done) {
+    var client = {
+    }
+
+    var S3 = proxyquire('../lib/S3', {
+      'knox': {
+          createClient: function () {
+              return client
+          }
+      }
+    })
+
+    var s3 = new S3({
+      key: 'PUT_YOUR_KEY_HERE',
+        secret: 'PUT_YOUR_BUCKET_HERE',
+        bucket: 'PUT_YOUR_BUCKET_HERE',
+        region: 'PUT_YOUR_REGION_HERE',
+        path: function (attachment) {
+        should(attachment).be.ok
+
+          return uploadPath
+        }
+    })
+
+    var ret;
+    ret = s3._queryResult(true, null, function(data){return data} )
+    ret.should.equal(true)
+
+    var res = {on : function(){}, statusCode : 200, req : { url : 'fakeurl'}}
+    ret = s3._queryResult(false, res, function(error, data){return data} )
+    ret.should.equal('fakeurl')
+
+    var err = new Error();
+    err.statusCode = 300;
+    err.body = 'mouse';
+
+    res = {
+      on : function(type, chunkfunc){ 
+      if ('data' === type ){
+        chunkfunc('mouse');
+      } else {
+        ret = chunkfunc()
+      }
+      },
+      statusCode : 300,
+    }
+    s3._queryResult(false, res, function(error){ return error} )
+
+    ret.should.eql(err)
+
+    done()
+})
 })


### PR DESCRIPTION
There is a bug in the S3 StorageProvider implementation. According to Amazon API you have to check res.StatusCode to be sure that request has been successfully processed. In the current Master branch version of the S3 provider, the 'save' / 'remove' function return no error even if you provide incorrect API keys.

BugFix is to check StatusCode and throw an Error with res.body that contain stringified object with Error description in case of StatusCode not in [200-209].