### PR TITLE
fix bug with removing attachments for custom path function

### DIFF
--- a/lib/S3.js
+++ b/lib/S3.js
@@ -1,4 +1,5 @@
 var path = require('path')
+var url = require('url')
 var knox = require('knox')
 var check = require('check-types')
 
@@ -47,8 +48,7 @@ S3StorageProvider.prototype.remove = function (attachment, callback) {
   if (!attachment.url) {
     return callback()
   }
-
-  this._client.deleteFile(path.basename(attachment.url), function (error, res) {
+    this._client.deleteFile(url.parse(attachment.url)['path'], function (error, res) {
     self._queryResult(error, res, callback)
   })
 }


### PR DESCRIPTION
When you are using custom path function you should parse stored url to get full path to stored file (url.parse(attachment.url)['path']) instead of (path.basename(attachment.url)).