### PR TITLE
use knox-s3 instead of knox to avoid breaking change in knox dependency

### DIFF
--- a/lib/S3.js
+++ b/lib/S3.js
@@ -2,7 +2,7 @@
 
 const path = require('path')
 const url = require('url')
-const knox = require('knox')
+const knox = require('knox-s3')
 const check = require('check-types')
 
 class S3StorageProvider {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "check-types": "^7.0.0",
-    "knox": "^0.9"
+    "knox-s3": "^0.9"
   },
   "devDependencies": {
     "async": "^2.1.4",


### PR DESCRIPTION
@dwjft has taken care of https://github.com/Automattic/knox/issues/326 by forking `knox` to https://www.npmjs.com/package/knox-s3

I just started experiencing the same issue d/t `mongoose-crate-s3`'s dependency on `knox`. Requiring `knox-s3` instead of `knox` resolved the `mime.lookup is not a function` issue for me.